### PR TITLE
Add optional cloud endpoint discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ sed -i -e "s/PRIVATEKEY/$(echo $PRIV_KEY_LOCATION | sed 's_/_\\/_g')/g" $IOT_CON
 sed -i -e "s/CERTPATH/$(echo $CERT_FILE | sed 's_/_\\/_g')/g" $IOT_CONFIG_FILE
 sed -i -e "s/CLIENT/$THING_NAME/g" $IOT_CONFIG_FILE
 sed -i -e "s/PORT/$PORT/g" $IOT_CONFIG_FILE
+sed -i -e "s/REGION/$AWS_REGION/g" $IOT_CONFIG_FILE
 cat $IOT_CONFIG_FILE
 ```
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ source ~/aws-iot-robot-connectivity-samples-ros2/workspace/install/setup.bash
 ros2 run telemetry_mqtt mqtt_telemetry_pub --ros-args --param path_for_config:=$IOT_CONFIG_FILE
 ```
 
+**Endpoint discovery**: this node also allows the use of cloud discovery, which allows the automatic discovery of AWS Greengrass core devices to connect to instead of a cloud endpoint. For more information on this option, please see the [developer guide](https://docs.aws.amazon.com/greengrass/v2/developerguide/connect-client-devices.html).
+
 To view the data being published, login to your AWS console to the MQTT test client page on the browser by searching for IoT Core in the search bar and selecting MQTT test client as shown below.
 ![IoT search bar](images/iot_core_console.png)
 Connect to the MQTT test client on the console as shown below

--- a/templates/iot_config_template.json
+++ b/templates/iot_config_template.json
@@ -4,6 +4,8 @@
     "certificatePath" : "CERTPATH",
     "privateKeyPath" : "PRIVATEKEY",
     "port" : PORT,
-    "clientID" : "CLIENT"
+    "clientID" : "CLIENT",
+    "region": "REGION",
+    "retryWaitTime": 5,
+    "retryAttempts": 10
 }
-

--- a/workspace/src/telemetry_mqtt/telemetry_mqtt/mqtt_telemetry_publisher.py
+++ b/workspace/src/telemetry_mqtt/telemetry_mqtt/mqtt_telemetry_publisher.py
@@ -21,8 +21,12 @@ import json
 import rclpy
 from rclpy.node import Node
 from std_msgs.msg import String
-from awscrt import mqtt, io, http, auth
+import time
+from awscrt import mqtt, io
 from awsiot import mqtt_connection_builder
+from awsiot.greengrass_discovery import DiscoveryClient
+
+RETRY_WAIT_TIME_SECONDS = 5
 
 
 class MqttPublisher(Node):
@@ -30,15 +34,27 @@ class MqttPublisher(Node):
         super().__init__('mqtt_publisher')
 
         self.declare_parameter("path_for_config", "")
+        self.declare_parameter("discover_endpoints", False)
+        self.declare_parameter("connection_retries", 5)
 
         path_for_config = self.get_parameter("path_for_config").get_parameter_value().string_value
+        discover_endpoints = self.get_parameter("discover_endpoints").get_parameter_value().bool_value
 
         with open(path_for_config) as f:
           cert_data = json.load(f)
 
         self.get_logger().info("Config we are loading is :\n{}".format(cert_data))
 
-        # Build mqtt connection
+        if discover_endpoints:
+            self.get_logger().info("Discovering endpoints for connection")
+            self.connect_using_discovery(cert_data)
+        else:
+            self.get_logger().info("Connecting directly to endpoint")
+            self.connect_to_endpoint(cert_data)
+
+        self.init_subs()
+
+    def connect_to_endpoint(self, cert_data):
         self.mqtt_conn = mqtt_connection_builder.mtls_from_path(
             endpoint=cert_data["endpoint"],
             port= cert_data["port"],
@@ -50,8 +66,70 @@ class MqttPublisher(Node):
         )
         connected_future = self.mqtt_conn.connect()
         connected_future.result()
+        self.get_logger().info("Connected!")
 
-        self.init_subs()
+    def connect_using_discovery(self, cert_data):
+        tries = 0
+
+        tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(
+            cert_data["certificatePath"],
+            cert_data["privateKeyPath"],
+        )
+        tls_options.override_default_trust_store_from_path(None, cert_data["rootCAPath"])
+        tls_context = io.ClientTlsContext(tls_options)
+
+        discovery_client = DiscoveryClient(
+            io.ClientBootstrap.get_or_create_static_default(),
+            io.SocketOptions(),
+            tls_context,
+            # TODO: Get region from config!
+            "us-west-2",
+        )
+        resp_future = discovery_client.discover(cert_data["clientID"])
+        discover_response = resp_future.result()
+        self.get_logger().debug(f"Discovery response is: {discover_response}")
+
+        for tries in range(self.get_parameter("connection_retries").value):
+            self.get_logger().info(f"Connection attempt: {tries}")
+            for gg_group in discover_response.gg_groups:
+                for gg_core in gg_group.cores:
+                    for connectivity_info in gg_core.connectivity:
+                        try:
+                            self.get_logger().debug(
+                                "Trying core {} as host {}:{}".format(
+                                    gg_core.thing_arn,
+                                    connectivity_info.host_address,
+                                    connectivity_info.port
+                                )
+                            )
+                            self.mqtt_conn = self.build_greengrass_connection(
+                                gg_group,
+                                connectivity_info,
+                                cert_data
+                            )
+                            return
+                        except Exception as e:
+                            self.get_logger().error(f"Connection failed with exception: {e}")
+                            continue
+            time.sleep(RETRY_WAIT_TIME_SECONDS)
+        raise Exception("All connection attempts failed!")
+
+    def build_greengrass_connection(self, gg_group, connectivity_info, cert_data):
+        conn = mqtt_connection_builder.mtls_from_path(
+            endpoint=connectivity_info.host_address,
+            port=connectivity_info.port,
+            cert_filepath=cert_data["certificatePath"],
+            pri_key_filepath=cert_data["privateKeyPath"],
+            ca_bytes=gg_group.certificate_authorities[0].encode('utf-8'),
+            client_id=cert_data["clientID"],
+            clean_session=False,
+            keep_alive_secs=30
+        )
+        connect_future = conn.connect()
+        connect_future.result()
+        self.get_logger().info("Connected!")
+        return conn
+
 
     def init_subs(self):
         """Subscribe to mock ros2 telemetry topic"""
@@ -59,16 +137,18 @@ class MqttPublisher(Node):
             String,
             'mock_telemetry',
             self.listener_callback,
-            10)
+            10
+        )
 
     def listener_callback(self, msg):
         """Callback for the mock ros2 telemetry topic"""
         message_json = msg.data
         self.get_logger().info("Received data on ROS2 {}\nPublishing to AWS IoT".format(msg.data))
         self.mqtt_conn.publish(
-                topic="ros2_mock_telemetry_topic",
-                payload=message_json,
-                qos=mqtt.QoS.AT_LEAST_ONCE)
+            topic="ros2_mock_telemetry_topic",
+            payload=message_json,
+            qos=mqtt.QoS.AT_LEAST_ONCE
+        )
 
 def main(args=None):
     rclpy.init(args=args)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a ROS2 parameter that optionally enables cloud discovery. This can be used if a Greengrass endpoint is set up to allow client device connections. Default is not to use cloud discovery.

Cloud discovery also allows retries for connection to allow time for Greengrass components to start up, if necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
